### PR TITLE
Change expiry alert status calculation 

### DIFF
--- a/opensrp-chw-core/src/main/java/org/smartregister/chw/core/utils/ChwServiceSchedule.java
+++ b/opensrp-chw-core/src/main/java/org/smartregister/chw/core/utils/ChwServiceSchedule.java
@@ -164,7 +164,7 @@ public class ChwServiceSchedule {
             Calendar today = Calendar.getInstance();
             standardiseCalendarDate(today);
 
-            if (expiredCal.getTimeInMillis() < today.getTimeInMillis()) {// expired
+            if (expiredCal.getTimeInMillis() <= today.getTimeInMillis()) {// expired
                 return AlertStatus.expired;
             } else if (dueCal.getTimeInMillis() <= today.getTimeInMillis()) {// Due
                 return AlertStatus.normal;


### PR DESCRIPTION
- The alert status turns to expired 24 hours after the date of expiry. 
- Set status to expiry if on the same date of expiry

----
Addresses https://github.com/OpenSRP/opensrp-client-chw/issues/1332